### PR TITLE
READY: Memory fix

### DIFF
--- a/hogan-express.coffee
+++ b/hogan-express.coffee
@@ -55,13 +55,6 @@ customContent = (str, tag, opt, partials) ->
   text = str.substring(str.indexOf(oTag) + oTag.length, str.indexOf(cTag))
   hogan.compile(text, opt).render(opt, partials)
 
-unescape = (t) ->
-  t.replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&#39;/g, "'")
-    .replace(/&quot;/g, '"')
-
 render = (path, opt, fn) ->
   ctx = this
   partials = opt.settings.partials or {}
@@ -95,8 +88,8 @@ render = (path, opt, fn) ->
           lctx = lctx extends opt._locals if opt._locals
           lctx = lctx extends lcontext
           
-          lcontext.lambdaVals[name][lambdaIndexes[name]] = unescape(lambda(hogan.compile(text).render(lctx)))
-          rtmpl = "{{ lambdaVals." + name + "." + lambdaIndexes[name] + " }}"
+          lcontext.lambdaVals[name][lambdaIndexes[name]] = lambda(hogan.compile(text).render(lctx))
+          rtmpl = "{{{ lambdaVals." + name + "." + lambdaIndexes[name] + " }}}"
           lambdaIndexes[name] = lambdaIndexes[name] + 1
           return rtmpl
 

--- a/hogan-express.js
+++ b/hogan-express.js
@@ -5,7 +5,7 @@
  */
 
 (function() {
-  var $, cache, ctx, customContent, hogan, read, render, renderLayout, renderPartials, unescape,
+  var $, cache, ctx, customContent, hogan, read, render, renderLayout, renderPartials,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
@@ -103,10 +103,6 @@
     return hogan.compile(text, opt).render(opt, partials);
   };
 
-  unescape = function(t) {
-    return t.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&#39;/g, "'").replace(/&quot;/g, '"');
-  };
-
   render = function(path, opt, fn) {
     var lambda, lambdaIndexes, lambdas, name, partials, _fn;
     ctx = this;
@@ -140,8 +136,8 @@
             lctx = __extends(lctx, opt._locals);
           }
           lctx = __extends(lctx, lcontext);
-          lcontext.lambdaVals[name][lambdaIndexes[name]] = unescape(lambda(hogan.compile(text).render(lctx)));
-          rtmpl = "{{ lambdaVals." + name + "." + lambdaIndexes[name] + " }}";
+          lcontext.lambdaVals[name][lambdaIndexes[name]] = lambda(hogan.compile(text).render(lctx));
+          rtmpl = "{{{ lambdaVals." + name + "." + lambdaIndexes[name] + " }}}";
           lambdaIndexes[name] = lambdaIndexes[name] + 1;
           return rtmpl;
         };


### PR DESCRIPTION
Somewhat hacky.

So! We have this code here that wraps lambdas in such a way that the original function is passed the value of the argument _after_ it is rendered. This lets it act as a filter. In our use case, that means that a given lambda will return (often multiple) unique values for each possible page it can be used on. This interacts poorly with hogan.js; it treats output of lambdas as templates to be compiled and cached. This leads to basically unbounded memory growth in our server processes, which is sad.

This fixes the memory problem by returning a much smaller set of possible values from each lambda. Each call of the lambda will produce a value in the context/opt, reachable with the lambda's name and a numeric indicator of how many times the lambda has been called in the current render invocation. Then the actual return value will be a template string referencing that value.

So let's say you had this template:

```
{{ #lambdas.capitalize }}stuff{{/lambdas.capitalize}}
{{ #lambdas.capitalize }}things{{/lambdas.capitalize}}
```

Currently, the output would be:

```
STUFF
THINGS
```

With this new code, it would be:

```
{{ lambdaVals.capitalize.0 }}
{{ lambdaVals.capitalize.1 }}
```

So for each lambda, the maximum number of times it will produce a new cache value is the maximum number of times that lambda can be reached in a single render call. This is more than 20 times in the case of some of our existing lambdas (gpt encoding, e.g.), but it's still bounded at a perfectly fine low-ish number. Even having a thousand templates cached is better than the tens of thousands we have now.

cc/ @FabledWeb 
